### PR TITLE
The builder/validators endpoint returns a signed registration

### DIFF
--- a/types/responses.yaml
+++ b/types/responses.yaml
@@ -4,7 +4,7 @@ ValidatorsResponseEntry:
     slot:
       $ref: "../beacon-apis/types/primitive.yaml#/Uint64"
     entry:
-      $ref: "../beacon-apis/types/registration.yaml#/ValidatorRegistration"
+      $ref: "../beacon-apis/types/registration.yaml#/SignedValidatorRegistration"
 
 ValidatorsResponse:
   type: array


### PR DESCRIPTION
Thanks for pointing this out. This should be a signed validator registration.

<img width="1442" alt="image" src="https://user-images.githubusercontent.com/95511699/201384882-9690dd39-944d-4f5d-b6ef-bf70fef3a431.png">

Fixes #2.

