### PR TITLE
Add builder_pubkey to params for data API

### DIFF
--- a/apis/relay/data/builder_blocks_received.yaml
+++ b/apis/relay/data/builder_blocks_received.yaml
@@ -26,6 +26,12 @@ get:
       description: A specific block number.
       schema:
         $ref: "../../../relay-oapi.yaml#/components/schemas/Uint64"
+    - name: builder_pubkey
+      in: query
+      required: false
+      description: A specific builder public key.
+      schema:
+        $ref: "../../../relay-oapi.yaml#/components/schemas/Pubkey"
     - name: limit
       in: query
       required: false

--- a/apis/relay/data/proposer_payload_delivered.yaml
+++ b/apis/relay/data/proposer_payload_delivered.yaml
@@ -44,6 +44,12 @@ get:
       description: A specific proposer public key.
       schema:
         $ref: "../../../relay-oapi.yaml#/components/schemas/Pubkey"
+    - name: builder_pubkey
+      in: query
+      required: false
+      description: A specific builder public key.
+      schema:
+        $ref: "../../../relay-oapi.yaml#/components/schemas/Pubkey"
     - name: order_by
       in: query
       required: false


### PR DESCRIPTION
As per https://github.com/flashbots/mev-boost-relay/pull/127 there has been additions to the Data API to filter by `builder_pubkey` to the `​/relay​/v1​/data​/bidtraces​/proposer_payload_delivered` and `​/relay​/v1​/data​/bidtraces​/builder_blocks_received` endpoints which is not reflected in the specs. Since it's already been implemented and deployed in the relay I think it should be included in the specs.