### PR TITLE
Update BidTrace

### DIFF
--- a/types/bids.yaml
+++ b/types/bids.yaml
@@ -28,7 +28,7 @@ BidTraceV2:
         num_tx:
           $ref: "../beacon-apis/types/primitive.yaml#/Uint64"
 
-BidTraceV2WithTimestamp:
+BidTraceV3:
   allOf:
     - $ref: "./bids.yaml#/BidTraceV2"
     - type: object
@@ -37,11 +37,5 @@ BidTraceV2WithTimestamp:
           $ref: "./misc.yaml#/Int64"
         timestamp_ms:
           $ref: "./misc.yaml#/Int64"
-
-BidTraceV3:
-  allOf:
-    - $ref: "./bids.yaml#/BidTraceV2WithTimestamp"
-    - type: object
-      properties:
         extra_data:
           $ref: "../beacon-apis/types/primitive.yaml#/ExtraData"

--- a/types/bids.yaml
+++ b/types/bids.yaml
@@ -37,3 +37,11 @@ BidTraceV2WithTimestamp:
           $ref: "./misc.yaml#/Int64"
         timestamp_ms:
           $ref: "./misc.yaml#/Int64"
+
+BidTraceV3:
+  allOf:
+    - $ref: "./bids.yaml#/BidTraceV2WithTimestamp"
+    - type: object
+      properties:
+        extra_data:
+          $ref: "../beacon-apis/types/primitive.yaml#/ExtraData"

--- a/types/responses.yaml
+++ b/types/responses.yaml
@@ -14,12 +14,12 @@ ValidatorsResponse:
 DeliveredPayloadsResponse:
   type: array
   items:
-    $ref: "./bids.yaml#/BidTraceV2"
+    $ref: "./bids.yaml#/BidTraceV3"
 
 ReceivedBlocksResponse:
   type: array
   items:
-    $ref: "./bids.yaml#/BidTraceV2WithTimestamp"
+    $ref: "./bids.yaml#/BidTraceV3"
 
 SubmitBlockResponseMessage:
   type: object


### PR DESCRIPTION
This PR updates the BidTrace(V2->V3) to include a timestamp by default and have an extra_data field. BidTraceV3 inherits from BidTraceV2WithTimestamp and adds an extra_data field as proposed by @metachris .

relay/v1/data/bidtraces/proposer_payload_delivered and relay/v1/data/bidtraces/builder_blocks_received endpoints both return a BidTraceV3 now.

The need for this proposal is discussed here:

https://github.com/flashbots/mev-boost-relay/issues/257