### PR TITLE
Checkout submodules recursively in GitHub actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
       - uses: actions/setup-node@v2
       - run: npm i -g @apidevtools/swagger-cli@4
       - name: Prepare deploy directory

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
       - uses: actions/setup-node@v2
       - run: npm i -g @apidevtools/swagger-cli@4
       - name: Bundle yaml spec


### PR DESCRIPTION
We need to initialize submodules recursively now. Otherwise the deploy step will fail:

* https://github.com/flashbots/relay-specs/actions/runs/5633149225/job/15261748673