### PR TITLE
Add proposer_pubkey to BidTraces

### DIFF
--- a/types/bids.yaml
+++ b/types/bids.yaml
@@ -9,6 +9,8 @@ BidTraceV1:
       $ref: "../beacon-apis/types/primitive.yaml#/Root"
     builder_pubkey:
       $ref: "../beacon-apis/types/primitive.yaml#/Pubkey"
+    proposer_pubkey:
+      $ref: "../beacon-apis/types/primitive.yaml#/Pubkey"
     proposer_fee_recipient:
       $ref: "../beacon-apis/types/primitive.yaml#/ExecutionAddress"
     gas_limit:


### PR DESCRIPTION
The `BidTrace` types are missing the `proposer_pubkey` fields. This PR fixes this.

Fixes #23.